### PR TITLE
ci: Add GitHub Actions workflow to deploy Hugo site to GitHub Pages

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,0 +1,74 @@
+# Sample workflow for building and deploying a Hugo site to GitHub Pages
+name: Deploy Hugo site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.127.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Build with Hugo
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          HUGO_ENVIRONMENT: production
+        run: |
+          hugo \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the build and deployment of a Hugo site to GitHub Pages. The workflow is designed to streamline the deployment process and includes steps for installing dependencies, building the site, and deploying it.

### New GitHub Actions Workflow for Hugo Deployment:

* **Workflow Name and Trigger**: Added a workflow named `Deploy Hugo site to Pages` that triggers on pushes to the `main` branch and can also be manually triggered via `workflow_dispatch`. (`[.github/workflows/hugo.ymlR1-R74](diffhunk://#diff-40a02c7a31ca0437cb4d959a3c117788bbb41ae8d4a39d4a995db6271b9887e3R1-R74)`)
* **Permissions and Concurrency**: Configured permissions for `GITHUB_TOKEN` to allow content reading and GitHub Pages deployment, and set up concurrency to prevent overlapping deployments. (`[.github/workflows/hugo.ymlR1-R74](diffhunk://#diff-40a02c7a31ca0437cb4d959a3c117788bbb41ae8d4a39d4a995db6271b9887e3R1-R74)`)
* **Build Job**: Added a `build` job that installs Hugo CLI, Dart Sass, and Node.js dependencies, checks out the repository, builds the Hugo site with production settings, and uploads the build artifact. (`[.github/workflows/hugo.ymlR1-R74](diffhunk://#diff-40a02c7a31ca0437cb4d959a3c117788bbb41ae8d4a39d4a995db6271b9887e3R1-R74)`)
* **Deployment Job**: Added a `deploy` job that uses the `actions/deploy-pages` action to deploy the built site to GitHub Pages, ensuring it runs after the `build` job. (`[.github/workflows/hugo.ymlR1-R74](diffhunk://#diff-40a02c7a31ca0437cb4d959a3c117788bbb41ae8d4a39d4a995db6271b9887e3R1-R74)`)